### PR TITLE
Use single_precision feature of fast_poisson crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.1.4"
 [dependencies]
 bevy = "0.11.3"
 bevy_editor_pls = { version = "0.5.0", optional = true }
-fast_poisson = "1.0.0"
+fast_poisson = { version = "1.0.0", features = ["single_precision"] }
 rand = "0.8.5"
 
 [features]

--- a/src/generators/poisson.rs
+++ b/src/generators/poisson.rs
@@ -37,10 +37,10 @@ pub fn poisson_generator(
           Poisson2D::new()
             .with_dimensions(
               [
-                (size.size.x - generator.item_width) as f64,
-                (size.size.y - generator.item_width) as f64,
+                size.size.x - generator.item_width,
+                size.size.y - generator.item_width,
               ],
-              generator.radius as f64,
+              generator.radius,
             )
             .iter()
             .for_each(|point| {
@@ -49,8 +49,8 @@ pub fn poisson_generator(
               parent.spawn(SpriteBundle {
                 texture: image_handle,
                 transform: Transform::from_translation(Vec3::new(
-                  point[0] as f32 - size.size.x / 2. + generator.item_width / 2.,
-                  point[1] as f32 - size.size.y / 2. + generator.item_width / 2.,
+                  point[0] - size.size.x / 2. + generator.item_width / 2.,
+                  point[1] - size.size.y / 2. + generator.item_width / 2.,
                   0.,
                 )),
                 ..default()


### PR DESCRIPTION
By enabling the `single_precision` feature of `fast_poisson`, we eliminate the need to cast between f32 and f64. Since the input is being cast from f32, and the output cast to f32, there's no benefit to be gained from using f64, and the casting operation itself may create a performance penalty.

Closes #1 